### PR TITLE
Fix for issue #35, so tutorial works correctly

### DIFF
--- a/colosseum/dimensions.py
+++ b/colosseum/dimensions.py
@@ -161,7 +161,7 @@ class Box:
     absolute_content_right: The right position of the box, relative to the block container
 
     """
-    def __init__(self, node, content_dimensions=(0,0)):
+    def __init__(self, node, content_dimensions=(0, 0)):
         self.node = node
         self._reset()
         self.content_width, self.content_height = content_dimensions

--- a/colosseum/dimensions.py
+++ b/colosseum/dimensions.py
@@ -161,9 +161,10 @@ class Box:
     absolute_content_right: The right position of the box, relative to the block container
 
     """
-    def __init__(self, node):
+    def __init__(self, node, content_dimensions=(0,0)):
         self.node = node
         self._reset()
+        self.content_width, self.content_height = content_dimensions
 
     def __repr__(self):
         return '<Box (%sx%s @ %s,%s)>' % (

--- a/docs/tutorial/tutorial-1.rst
+++ b/docs/tutorial/tutorial-1.rst
@@ -21,7 +21,7 @@ node is the following::
             self.parent = None
             self.children = []
             self.intrinsic = Size(self)
-            self.layout = Box(self)
+            self.layout = Box(self, (style.width, style.height))
             self.style = style.copy(self)
 
         def add(self, child):


### PR DESCRIPTION
Fixes issue #35 

Added optional content_dimensions argument to Box, and updated `tutorial-1` accordingly to fix MyDOMNode init bug. Previously, the layout was not correctly printed, unlike what is stated in the tutorial

I updated the last line in `Box` class:
![image](https://user-images.githubusercontent.com/30549145/70458909-04c57280-1aab-11ea-8966-4eb35a10e1de.png)

And updated the tutorial to accept the optional argument at https://colosseum.readthedocs.io/en/latest/tutorial/tutorial-1.html:
![image](https://user-images.githubusercontent.com/30549145/70458678-8072ef80-1aaa-11ea-95ad-2061584a2dc8.png)