### PR TITLE
PR: Fixes points to pica test and updates px calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ local
 distribute-*
 .coverage
 .tox
+*.DS_Store

--- a/colosseum/units.py
+++ b/colosseum/units.py
@@ -116,7 +116,7 @@ em = FontUnit('em')
 ex = FontUnit('ex')
 ch = FontUnit('ch')
 
-pc = AbsoluteUnit('pc', 6)
+pc = AbsoluteUnit('pc', 12)
 pt = AbsoluteUnit('pt', 1)
 inch = AbsoluteUnit('in', 72)
 cm = AbsoluteUnit('cm', 28.3465)

--- a/colosseum/units.py
+++ b/colosseum/units.py
@@ -19,7 +19,10 @@ class Unit:
         return round(LU_PER_PIXEL * self.val)
 
     def px(self, display=None, font=None, size=None):
-        return self.lu(display=display, font=font, size=size) // LU_PER_PIXEL
+        logical_units = self.lu(display=display, font=font, size=size)
+        value = logical_units / LU_PER_PIXEL
+        int_value = int(value)
+        return int_value if value == int_value else value
 
     def __repr__(self):
         return '{}{}'.format(self.val, self.suffix)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -54,15 +54,15 @@ class BaseUnitTests(TestCase):
 
         p = 0.2 * px
         self.assertEqual(p.lu(display=self.display), 13)
-        self.assertEqual(p.px(display=self.display), 0)
+        self.assertEqual(p.px(display=self.display), 0.203125)
 
         p = 0.5 * px
         self.assertEqual(p.lu(display=self.display), 32)
-        self.assertEqual(p.px(display=self.display), 0)
+        self.assertEqual(p.px(display=self.display), 0.5)
 
         p = 0.7 * px
         self.assertEqual(p.lu(display=self.display), 45)
-        self.assertEqual(p.px(display=self.display), 0)
+        self.assertEqual(p.px(display=self.display), 0.703125)
 
         p = 1 * px
         self.assertEqual(p.lu(display=self.display), 64)
@@ -70,15 +70,15 @@ class BaseUnitTests(TestCase):
 
         p = 1.2 * px
         self.assertEqual(p.lu(display=self.display), 77)
-        self.assertEqual(p.px(display=self.display), 1)
+        self.assertEqual(p.px(display=self.display), 1.203125)
 
         p = 1.5 * px
         self.assertEqual(p.lu(display=self.display), 96)
-        self.assertEqual(p.px(display=self.display), 1)
+        self.assertEqual(p.px(display=self.display), 1.5)
 
         p = 1.7 * px
         self.assertEqual(p.lu(display=self.display), 109)
-        self.assertEqual(p.px(display=self.display), 1)
+        self.assertEqual(p.px(display=self.display), 1.703125)
 
         p = 2 * px
         self.assertEqual(p.lu(display=self.display), 128)
@@ -141,14 +141,14 @@ class AbsoluteUnitTests(TestCase):
 
     def test_pica(self):
         p = 1 * pc
-        self.assertEqual(p.lu(display=self.simple), 512)
-        self.assertEqual(p.lu(display=self.print), 1600)
-        self.assertEqual(p.lu(display=self.hidpi), 1739)
+        self.assertEqual(p.lu(display=self.simple), 1024)
+        self.assertEqual(p.lu(display=self.print), 3200)
+        self.assertEqual(p.lu(display=self.hidpi), 3477)
 
         p = 5 * pc
-        self.assertEqual(p.lu(display=self.simple), 2560)
-        self.assertEqual(p.lu(display=self.print), 8000)
-        self.assertEqual(p.lu(display=self.hidpi), 8693)
+        self.assertEqual(p.lu(display=self.simple), 5120)
+        self.assertEqual(p.lu(display=self.print), 16000)
+        self.assertEqual(p.lu(display=self.hidpi), 17387)
 
         self.assertEqual(str(p), "5pc")
         self.assertEqual(repr(p), "5pc")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,7 +23,7 @@ class Display:
 
 
 class TestNode:
-    def __init__(self, name=None,style=None, children=None):
+    def __init__(self, name=None, style=None, children=None):
         self.name = name if name else 'div'
         self.parent = None
         self.children = []

--- a/tests/web_platform/CSS2/normal_flow/not_implemented
+++ b/tests/web_platform/CSS2/normal_flow/not_implemented
@@ -167,10 +167,8 @@ blocks_025
 blocks_026
 height_006
 height_007
-height_014
 height_017
 height_018
-height_025
 height_028
 height_029
 height_036
@@ -573,10 +571,6 @@ replaced_intrinsic_004
 replaced_intrinsic_005
 root_box_001
 table_in_inline_001
-width_014
-width_025
-width_028
-width_029
 width_036
 width_047
 width_068


### PR DESCRIPTION
This PR fixes an issue with pica to points units.
- [x] Tests are updated
- [x] A new way to calculate px units so that rounded values return ints, but float values return floats (before everything was returning truncated values)
- [x] This update fixed 6 tests

I was not sure if two separate PRs were required, can do it if you prefer so @freakboy3742 