### PR TITLE
Updated build_document and fixed five tests.

### DIFF
--- a/colosseum/engine.py
+++ b/colosseum/engine.py
@@ -651,9 +651,14 @@ def calculate_block_non_replaced_normal_flow_height(node, context):
                 content_height = node.style.min_height.px(**context)
             else:
                 content_height = 0
-
     else:
-        content_height = node.style.height.px(**context)
+        if node.parent is not None and node.parent.style.height is not AUTO:
+            parent_height = node.parent.style.height.px(**context)
+            content_height = node.style.height.px(
+                display=context['display'], font=context['font'], size=parent_height
+            )
+        else:
+            content_height = node.style.height.px(**context)
         if node.style.max_height is not None:  # 10.7 Maximum height
             content_max_height = node.style.max_height.px(**context)
             if content_height > content_max_height:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,9 +39,10 @@ class TestNode:
         return '<{}:{} {}>'.format(self.name, id(self), str(self.layout))
 
 
-def build_document(data):
+def build_document(data, parent=None):
     if 'tag' in data:
         node = TestNode(name=data['tag'])
+        node.parent = parent
         node.style.update(**{
             attr: value
             for attr, value in data['style'].items()
@@ -50,7 +51,7 @@ def build_document(data):
 
         if 'children' in data:
             for child in data['children']:
-                subdocument = build_document(child)
+                subdocument = build_document(child, parent=node)
                 if subdocument:
                     node.children.append(subdocument)
     else:

--- a/tests/web_platform/CSS2/box_display/not_implemented
+++ b/tests/web_platform/CSS2/box_display/not_implemented
@@ -12,10 +12,8 @@ block_in_inline_relpos_002
 box_generation_001
 box_generation_002
 box_generation_003
-containing_block_001
 containing_block_002
 containing_block_003
-containing_block_004
 containing_block_005
 containing_block_006
 containing_block_007

--- a/tests/web_platform/CSS2/normal_flow/not_implemented
+++ b/tests/web_platform/CSS2/normal_flow/not_implemented
@@ -161,7 +161,6 @@ blocks_017
 blocks_018
 blocks_019
 blocks_021
-blocks_022
 blocks_025
 blocks_026
 height_006
@@ -182,7 +181,6 @@ height_073
 height_080
 height_083
 height_084
-height_091
 height_094
 height_095
 height_104
@@ -205,7 +203,6 @@ height_applies_to_014
 height_applies_to_015
 height_applies_to_016
 height_inherit_001
-height_percentage_001
 height_percentage_002
 height_percentage_003
 height_percentage_004


### PR DESCRIPTION
The build_document function now sets node.parent to help ensure all child TestNodes have parent correctly set.

This has made it possible to fix five tests that include children with heights specified as a percentage.



