### PR TITLE
Added negative check and is_percentage validator tests

### DIFF
--- a/changes/75.misc.rst
+++ b/changes/75.misc.rst
@@ -1,0 +1,1 @@
+Added a negative percentage check in the validator, and added less than dunder to Percentage class.

--- a/src/colosseum/units.py
+++ b/src/colosseum/units.py
@@ -147,6 +147,7 @@ class Percent(Unit):
     def __lt__(self, other):
         return self.val < other.val
 
+
 px = PixelUnit()
 
 em = FontUnit('em')

--- a/src/colosseum/units.py
+++ b/src/colosseum/units.py
@@ -144,6 +144,8 @@ class Percent(Unit):
             return self.val == other.val and self.suffix == other.suffix
         return False
 
+    def __lt__(self, other):
+        return self.val < other.val
 
 px = PixelUnit()
 

--- a/src/colosseum/validators.py
+++ b/src/colosseum/validators.py
@@ -90,7 +90,7 @@ def is_percentage(value):
         raise ValidationError(error_msg)
 
     if value < units.Percent(0):
-        error_msg = 'Value {value} can not negative'.format(value=value);
+        error_msg = 'Value {value} can not negative'.format(value=value)
         raise ValidationError(error_msg)
 
     return value

--- a/src/colosseum/validators.py
+++ b/src/colosseum/validators.py
@@ -89,6 +89,10 @@ def is_percentage(value):
         error_msg = 'Value {value} is not a Percent unit'.format(value=value)
         raise ValidationError(error_msg)
 
+    if value < units.Percent(0):
+        error_msg = 'Value {value} can not negative'.format(value=value);
+        raise ValidationError(error_msg)
+
     return value
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -15,19 +15,19 @@ from colosseum.validators import (
 )
 from colosseum.wrappers import Quotes
 
+
 class PercentTests(TestCase):
     def test_percentage(self):
-        percent_value = is_percentage("100%");
+        percent_value = is_percentage("100%")
 
         self.assertEqual(percent_value, 100*percent)
-        # import pdb;pdb.set_trace()
         self.assertEqual(type(percent_value), type(percent))
 
         with self.assertRaises(ValidationError):
-            is_percentage("-100%");
+            is_percentage("-100%")
 
         with self.assertRaises(ValidationError):
-            is_percentage("100");
+            is_percentage("100")
 
         with self.assertRaises(ValidationError):
             is_percentage('spam')

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,18 +1,36 @@
 from unittest import TestCase
 
 from colosseum.shapes import Rect
-from colosseum.units import px
+from colosseum.units import px, percent
 from colosseum.validators import (
     ValidationError,
     is_border_spacing,
     is_cursor,
     is_integer,
     is_number,
+    is_percentage,
     is_quote,
     is_rect,
     is_uri,
 )
 from colosseum.wrappers import Quotes
+
+class PercentTests(TestCase):
+    def test_percentage(self):
+        percent_value = is_percentage("100%");
+
+        self.assertEqual(percent_value, 100*percent)
+        # import pdb;pdb.set_trace()
+        self.assertEqual(type(percent_value), type(percent))
+
+        with self.assertRaises(ValidationError):
+            is_percentage("-100%");
+
+        with self.assertRaises(ValidationError):
+            is_percentage("100");
+
+        with self.assertRaises(ValidationError):
+            is_percentage('spam')
 
 
 class NumericTests(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -21,14 +21,12 @@ deps =
 commands = flake8 {posargs}
 
 [testenv:towncrier-check]
-skip_install = True
 deps =
     {[testenv:towncrier]deps}
 commands =
     python -m towncrier.check
 
 [testenv:towncrier]
-skip_install = True
 deps =
     towncrier >= 18.5.0
 commands =


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Add a check in the is_percentage validator so that it doesn't allow negative percentages.
<!--- What problem does this change solve? -->
This ensures that when the percentage unit is validated, that it can't be negative.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
https://github.com/beeware/colosseum/issues/75

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
I'm unsure if this check needs documentation, but guidance on whether or not it does is greatly appreciated.
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
