### PR TITLE
Bump black-pre-commit-mirror from 24.10.0 to 25.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py39-plus]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
     - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/changes/103.misc.rst
+++ b/changes/103.misc.rst
@@ -1,0 +1,1 @@
+The ``pre-commit`` hook for ``black-pre-commit-mirror`` was updated to its latest version.

--- a/tests/test_declaration.py
+++ b/tests/test_declaration.py
@@ -1044,7 +1044,7 @@ class CssDeclarationTests(TestCase):
             node.style.quotes = [">"]
 
         with self.assertRaises(ValueError):
-            node.style.quotes = [(">")]
+            node.style.quotes = [">"]
 
     ##############################################################################
     # Outline shorthand


### PR DESCRIPTION
Bumps `pre-commit` hook for `black-pre-commit-mirror` from 24.10.0 to 25.1.0 and ran the update against the repo.