### PR TITLE
Bump ruff-pre-commit from v0.15.4 to v0.15.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.9
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/changes/203.misc.md
+++ b/changes/203.misc.md
@@ -1,0 +1,1 @@
+`pre-commit` hook for `ruff-pre-commit` is now updated from v0.15.4 to v0.15.9.


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.15.4 to v0.15.9 and ran the update against the repo.