### PR TITLE
Bump ruff-pre-commit from v0.15.9 to v0.15.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+    rev: v0.15.12
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/changes/205.misc.rst
+++ b/changes/205.misc.rst
@@ -1,0 +1,1 @@
+The `pre-commit` hook for `ruff-pre-commit` was updated to its latest version.


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.15.9 to v0.15.12 and ran the update against the repo.