### PR TITLE
Pin pypa/gh-action-pypi-publish to v1.14.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,4 +19,4 @@ jobs:
           target: dist/
 
       - name: Publish release to production PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,6 @@ jobs:
           artifactErrorsFailBuild: true
 
       - name: Publish release to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
         with:
           repository_url: https://test.pypi.org/legacy/

--- a/changes/218.misc.rst
+++ b/changes/218.misc.rst
@@ -1,0 +1,1 @@
+Pinned the pypa/gh-action-pypi-publish action to a specific commit (v1.14.1) instead of a mutable branch reference.


### PR DESCRIPTION
Pins `pypa/gh-action-pypi-publish` to commit `ba38be9e461d3875417946c167d0b5f3d385a247` (tag `v1.14.1`) instead of the mutable `release/v1` branch reference.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 5
